### PR TITLE
Improve accessibility of risk tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,51 +98,51 @@
       <td>1</td>
       <td>Slight health effect – First Aid Case or Less</td>
       <td>Slight effect – Immediate clean up by one or two persons</td>
-      <td class="green tooltip" data-tooltip="Low Risk">1A</td>
-      <td class="green tooltip" data-tooltip="Low Risk">1B</td>
-      <td class="green tooltip" data-tooltip="Low Risk">1C</td>
-      <td class="green tooltip" data-tooltip="Low Risk">1D</td>
-      <td class="green tooltip" data-tooltip="Low Risk">1E</td>
+      <td class="green tooltip" data-tooltip="Low Risk" aria-label="Low Risk">1A</td>
+      <td class="green tooltip" data-tooltip="Low Risk" aria-label="Low Risk">1B</td>
+      <td class="green tooltip" data-tooltip="Low Risk" aria-label="Low Risk">1C</td>
+      <td class="green tooltip" data-tooltip="Low Risk" aria-label="Low Risk">1D</td>
+      <td class="green tooltip" data-tooltip="Low Risk" aria-label="Low Risk">1E</td>
     </tr>
     <tr>
       <td>2</td>
       <td>Minor health effect – Medical Treatment, Restricted Duty</td>
       <td>Minor effect – Internal crew required for cleanup</td>
-      <td class="green tooltip" data-tooltip="Low Risk">2A</td>
-      <td class="green tooltip" data-tooltip="Low Risk">2B</td>
-      <td class="green tooltip" data-tooltip="Low Risk">2C</td>
-      <td class="yellow tooltip" data-tooltip="Medium Risk">2D</td>
-      <td class="yellow tooltip" data-tooltip="Medium Risk">2E</td>
+      <td class="green tooltip" data-tooltip="Low Risk" aria-label="Low Risk">2A</td>
+      <td class="green tooltip" data-tooltip="Low Risk" aria-label="Low Risk">2B</td>
+      <td class="green tooltip" data-tooltip="Low Risk" aria-label="Low Risk">2C</td>
+      <td class="yellow tooltip" data-tooltip="Medium Risk" aria-label="Medium Risk">2D</td>
+      <td class="yellow tooltip" data-tooltip="Medium Risk" aria-label="Medium Risk">2E</td>
     </tr>
     <tr>
       <td>3</td>
       <td>Major health effect – Lost Time Workday, Permanent Disability</td>
       <td>Localized effect – Trained team required, reported to client</td>
-      <td class="green tooltip" data-tooltip="Low Risk">3A</td>
-      <td class="green tooltip" data-tooltip="Low Risk">3B</td>
-      <td class="yellow tooltip" data-tooltip="Medium Risk">3C</td>
-      <td class="yellow tooltip" data-tooltip="Medium Risk">3D</td>
-      <td class="red tooltip" data-tooltip="High Risk">3E</td>
+      <td class="green tooltip" data-tooltip="Low Risk" aria-label="Low Risk">3A</td>
+      <td class="green tooltip" data-tooltip="Low Risk" aria-label="Low Risk">3B</td>
+      <td class="yellow tooltip" data-tooltip="Medium Risk" aria-label="Medium Risk">3C</td>
+      <td class="yellow tooltip" data-tooltip="Medium Risk" aria-label="Medium Risk">3D</td>
+      <td class="red tooltip" data-tooltip="High Risk" aria-label="High Risk">3E</td>
     </tr>
     <tr>
       <td>4</td>
       <td>1–3 fatalities</td>
       <td>Major effect – External aid required for cleanup</td>
-      <td class="green tooltip" data-tooltip="Low Risk">4A</td>
-      <td class="yellow tooltip" data-tooltip="Medium Risk">4B</td>
-      <td class="yellow tooltip" data-tooltip="Medium Risk">4C</td>
-      <td class="red tooltip" data-tooltip="High Risk">4D</td>
-      <td class="red tooltip" data-tooltip="High Risk">4E</td>
+      <td class="green tooltip" data-tooltip="Low Risk" aria-label="Low Risk">4A</td>
+      <td class="yellow tooltip" data-tooltip="Medium Risk" aria-label="Medium Risk">4B</td>
+      <td class="yellow tooltip" data-tooltip="Medium Risk" aria-label="Medium Risk">4C</td>
+      <td class="red tooltip" data-tooltip="High Risk" aria-label="High Risk">4D</td>
+      <td class="red tooltip" data-tooltip="High Risk" aria-label="High Risk">4E</td>
     </tr>
     <tr>
       <td>5</td>
       <td>More than 3 fatalities</td>
       <td>Massive effect – National emergency</td>
-      <td class="yellow tooltip" data-tooltip="Medium Risk">5A</td>
-      <td class="yellow tooltip" data-tooltip="Medium Risk">5B</td>
-      <td class="red tooltip" data-tooltip="High Risk">5C</td>
-      <td class="red tooltip" data-tooltip="High Risk">5D</td>
-      <td class="red tooltip" data-tooltip="High Risk">5E</td>
+      <td class="yellow tooltip" data-tooltip="Medium Risk" aria-label="Medium Risk">5A</td>
+      <td class="yellow tooltip" data-tooltip="Medium Risk" aria-label="Medium Risk">5B</td>
+      <td class="red tooltip" data-tooltip="High Risk" aria-label="High Risk">5C</td>
+      <td class="red tooltip" data-tooltip="High Risk" aria-label="High Risk">5D</td>
+      <td class="red tooltip" data-tooltip="High Risk" aria-label="High Risk">5E</td>
     </tr>
   </table>
 
@@ -154,19 +154,19 @@
       <th>Description</th>
     </tr>
     <tr>
-      <td class="red tooltip" data-tooltip="High Risk">3E – 5E</td>
-      <td class="tooltip" data-tooltip="High Risk"><strong>High</strong></td>
-      <td class="tooltip" data-tooltip="High Risk">Isolate hazard immediately. Work cannot proceed unless risk is reduced. Method Statements required for 5E.</td>
+      <td class="red tooltip" data-tooltip="High Risk" aria-label="High Risk">3E – 5E</td>
+      <td class="tooltip" data-tooltip="High Risk" aria-label="High Risk"><strong>High</strong></td>
+      <td class="tooltip" data-tooltip="High Risk" aria-label="High Risk">Isolate hazard immediately. Work cannot proceed unless risk is reduced. Method Statements required for 5E.</td>
     </tr>
     <tr>
-      <td class="yellow tooltip" data-tooltip="Medium Risk">2D – 5B</td>
-      <td class="tooltip" data-tooltip="Medium Risk"><strong>Medium</strong></td>
-      <td class="tooltip" data-tooltip="Medium Risk">Isolate hazard as soon as practicable. Ensure competent persons, supervision, and inspections are in place.</td>
+      <td class="yellow tooltip" data-tooltip="Medium Risk" aria-label="Medium Risk">2D – 5B</td>
+      <td class="tooltip" data-tooltip="Medium Risk" aria-label="Medium Risk"><strong>Medium</strong></td>
+      <td class="tooltip" data-tooltip="Medium Risk" aria-label="Medium Risk">Isolate hazard as soon as practicable. Ensure competent persons, supervision, and inspections are in place.</td>
     </tr>
     <tr>
-      <td class="green tooltip" data-tooltip="Low Risk">1A – 4A</td>
-      <td class="tooltip" data-tooltip="Low Risk"><strong>Low</strong></td>
-      <td class="tooltip" data-tooltip="Low Risk">Fix causes when time permits. Use PPE, maintain situational awareness, and ensure clear communication.</td>
+      <td class="green tooltip" data-tooltip="Low Risk" aria-label="Low Risk">1A – 4A</td>
+      <td class="tooltip" data-tooltip="Low Risk" aria-label="Low Risk"><strong>Low</strong></td>
+      <td class="tooltip" data-tooltip="Low Risk" aria-label="Low Risk">Fix causes when time permits. Use PPE, maintain situational awareness, and ensure clear communication.</td>
     </tr>
   </table>
 
@@ -174,7 +174,8 @@
     <h1>Task-Based Risk Assessment</h1>
     <div class="task-controls">
       <h3>Create New Task</h3>
-      <textarea id="taskDesc" placeholder="Describe the task..."></textarea>
+      <label for="taskDesc">Task Description</label>
+      <textarea id="taskDesc" placeholder="Describe the task..." aria-label="Task Description"></textarea>
       <button onclick="addTask()">Add Task</button>
       <button onclick="exportToJSON()">Export</button>
     </div>

--- a/script.js
+++ b/script.js
@@ -68,6 +68,11 @@ function getRiskClass(severity, likelihood) {
   return level.toLowerCase() + '-risk';
 }
 
+function getRiskLevel(severity, likelihood) {
+  const key = severity + likelihood;
+  return riskMatrix[key] || 'Low';
+}
+
 function renderTable() {
   const tbody = document.getElementById('tableBody');
   tbody.innerHTML = '';
@@ -185,8 +190,8 @@ function renderHazardCols(taskId, hazard) {
   return `
     <td>
       <span id="hazard-desc-${hazard.id}">${hazard.description}</span><br/>
-      <button onclick="editHazard(${taskId}, ${hazard.id})">✏️</button>
-      <button onclick="deleteHazard(${taskId}, ${hazard.id})">🗑️</button>
+      <button onclick="editHazard(${taskId}, ${hazard.id})" aria-label="Edit hazard">✏️</button>
+      <button onclick="deleteHazard(${taskId}, ${hazard.id})" aria-label="Delete hazard">🗑️</button>
     </td>
     <td>
       <select onchange="updateRisk(${taskId}, ${hazard.id}, 'initSeverity', this.value)">
@@ -195,13 +200,13 @@ function renderHazardCols(taskId, hazard) {
       <select onchange="updateRisk(${taskId}, ${hazard.id}, 'initLikelihood', this.value)">
         ${['A','B','C','D','E'].map(l => `<option value="${l}" ${l==hazard.initLikelihood?'selected':''}>${l}</option>`).join('')}
       </select>
-      <span class="risk-tag ${getRiskClass(hazard.initSeverity, hazard.initLikelihood)}">${hazard.initSeverity}${hazard.initLikelihood}</span>
+      <span class="risk-tag ${getRiskClass(hazard.initSeverity, hazard.initLikelihood)}" aria-label="${getRiskLevel(hazard.initSeverity, hazard.initLikelihood)} Risk">${hazard.initSeverity}${hazard.initLikelihood}</span>
     </td>
     <td>
       <button onclick="toggleControls(${taskId}, ${hazard.id})">${hazard.expanded ? 'Hide' : 'Show'} Controls</button>
       ${hazard.expanded ? `
       <ul class="controls-list">
-        ${hazard.controls.map((c, i) => `<li>${c} <button onclick="editControl(${taskId},${hazard.id},${i})">✏️</button> <button onclick="deleteControl(${taskId},${hazard.id},${i})">🗑️</button></li>`).join('')}
+        ${hazard.controls.map((c, i) => `<li>${c} <button onclick="editControl(${taskId},${hazard.id},${i})" aria-label="Edit control">✏️</button> <button onclick="deleteControl(${taskId},${hazard.id},${i})" aria-label="Delete control">🗑️</button></li>`).join('')}
       </ul>
       <input id="control-${taskId}-${hazard.id}" placeholder="Add control measure" />
       <button onclick="addControl(${taskId}, ${hazard.id})">Add Control</button>
@@ -214,7 +219,7 @@ function renderHazardCols(taskId, hazard) {
       <select onchange="updateResidualRisk(${taskId}, ${hazard.id}, 'likelihood', this.value)">
         ${['A','B','C','D','E'].map(l => `<option value="${l}" ${l==hazard.residualLikelihood?'selected':''}>${l}</option>`).join('')}
       </select>
-      <span class="risk-tag ${getRiskClass(hazard.residualSeverity, hazard.residualLikelihood)}">${hazard.residualSeverity}${hazard.residualLikelihood}</span>
+      <span class="risk-tag ${getRiskClass(hazard.residualSeverity, hazard.residualLikelihood)}" aria-label="${getRiskLevel(hazard.residualSeverity, hazard.residualLikelihood)} Risk">${hazard.residualSeverity}${hazard.residualLikelihood}</span>
     </td>
   `;
 }


### PR DESCRIPTION
## Summary
- label the task description textarea
- add `aria-label` to risk matrix cells and categories
- expose risk level text and ARIA labels for dynamic risk tags and buttons

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_686c15876fa88321a2a6606a73f33f42